### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-#Open-m-monit on Nodejs
+# Open-m-monit on Nodejs
 
 
-###Clone this repo and do the follow:
+### Clone this repo and do the follow:
 1. Create the file config.json and add your monit servers:
 
 ```javascript


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
